### PR TITLE
Include tests from `test262`, `esprima` and `hermes` in example corpus

### DIFF
--- a/scripts/corpora/js.sh
+++ b/scripts/corpora/js.sh
@@ -3,6 +3,8 @@
 set -e
 
 repos=(
+  "tc39/test262"
+  "jquery/esprima"
   "v8/v8"
   "mozilla/gecko-dev"
   "svaarala/duktape"
@@ -13,6 +15,7 @@ repos=(
   "cesanta/elk"
   "Starlight-JS/starlight"
   "denoland/deno"
+  "facebook/hermes"
 )
 mkdir -p js
 for repo in "${repos[@]}"; do


### PR DESCRIPTION
For folks using the corpus script as the initial corpora to start fuzzing, I thought it would be useful to include unit tests from test suites that are commonly used during JS engine development and tests from  [Hermes](https://github.com/facebook/hermes)